### PR TITLE
Add input.branch parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   token:
     description: 'Repository upload token - get it from codecov.io. Required only for private repositories'
     required: false
+  branch:
+    description: 'Override branch, if using other than the default branch'
+    required: false
   fail_ci_if_error:
     description: 'Specify whether or not CI build should fail if Codecov runs into an error during upload'
     required: false
@@ -23,5 +26,6 @@ runs:
     - uses: codecov/codecov-action@v2
       with:
         token: ${{ inputs.token }}
+        override_branch: ${{ inputs.branch }}
         verbose: ${{ inputs.verbose }}
         fail_ci_if_error: ${{ inputs.fail_ci_if_error }}


### PR DESCRIPTION
When this workflow runs in a branch other than the default branch, uploaded results to codecov.io are mixed. In codecov.io, I see the source code of the default branch with the coverage results of a different branch, leading to inconsistencies (for example, when few lines were not covered in the default branch and are removed in the other branch).
The `input.branch` parameter allows to specify the branch under test. This is specially useful when running this workflow triggered by another workflow, e.g. `unit-tests.yml`. Thus, in `coverage.yml` one can specify:

```yml
on:
  workflow_run:
    workflows: [Unit test]
    types: [completed]
    branches:
      - main
      - develop

jobs:
  coverage:
    runs-on: ubuntu-latest
    if: $ {{ github.event.workflow_run.conclusion == 'success' }}

  steps:
    ...

    - name: Upload coverage reports to Codecov
      uses: alire-project/gnatcov-to-codecov-action@main
      with:
        token: ${{ secrets.CODECOV_TOKEN }}
        branch: ${{ github.event.workflow_run.head_branch }}
```

Using the `branch` argument, uploaded results to codecov.io are displayed under the corresponding `Branch Context` and results are not mixed.
